### PR TITLE
Exclude jasper libs already contained in servlet to fix test error

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,10 +15,9 @@ dependencies {
   compile ('com.google.guava:guava:14.0.1') {
     force = true
   }
-  testCompile 'org.apache.hadoop:hadoop-minicluster:2.5.1'
-  testCompile "org.apache.hbase:hbase-server:1.4.1"
-  testCompile "org.apache.hbase:hbase-server:1.4.1:tests"
-  testCompile 'org.apache.hbase:hbase-hadoop-compat:1.4.1:tests'
-  testCompile 'org.apache.hbase:hbase-hadoop2-compat:1.4.1:tests'
+  testCompile('org.apache.hbase:hbase-testing-util:1.4.1') {
+    exclude group: 'tomcat', module: 'jasper-compiler'
+    exclude group: 'tomcat', module: 'jasper-runtime'
+  }
   testCompile 'junit:junit:4.11'
 }

--- a/src/test/java/local/example/HbaseTest.java
+++ b/src/test/java/local/example/HbaseTest.java
@@ -23,7 +23,7 @@ public class HbaseTest {
   public void setUp() throws Exception {
     System.setProperty("org.apache.hadoop.hbase.shaded.io.netty.packagePrefix",
             "org.apache.hadoop.hbase.shaded.");
-    utility = HBaseTestingUtility.createLocalHTU();
+    utility = new HBaseTestingUtility();
     utility.startMiniCluster();
     HTable table = utility.createTable(TableName.valueOf("mutator_test_table"),
         new byte[][]{Bytes.toBytes("protocols"), Bytes.toBytes("metadata"), Bytes.toBytes("sys")});


### PR DESCRIPTION
Via [HBASE-17940](https://issues.apache.org/jira/browse/HBASE-17940), it seems like the following stacktrace we were seeing from tests (`./gradlew test --info`):

```
2018-03-26 14:48:06,351 ERROR [Test worker] mortbay.log (Slf4jLog.java:warn(87)) - Error starting handlers
 java.lang.NoSuchFieldError: IS_SECURITY_ENABLED
     at org.apache.jasper.compiler.JspRuntimeContext.<init>(JspRuntimeContext.java:197)
     at org.apache.jasper.servlet.JspServlet.init(JspServlet.java:150)
     at org.mortbay.jetty.servlet.ServletHolder.initServlet(ServletHolder.java:440)
     at org.mortbay.jetty.servlet.ServletHolder.doStart(ServletHolder.java:263)
…
```

…was because of a conflict in `jasper-compiler`+`jasper-runtime` dependencies. Seemingly excluding them via our gradle configuration does the trick.

This also means we can consolidate our testCompile dependencies to solely `org.apache.hbase:hbase-testing-util:1.4.1`.